### PR TITLE
Persistent scenes

### DIFF
--- a/convergame.js
+++ b/convergame.js
@@ -31,13 +31,18 @@ function Convergame(canvas) {
     
     var i;
 
+    // 1. Run updateFunction for all persistentScenes (allows main scene to reference data set in persistentScenes)
     for (i = 0; i < this.persistentScenes.length; i++) {
         this.persistentScenes[i].updateFunction(time);
     }
 
+    // 2. Run updateFunction main scene
     this.scene.updateFunction(time);
+    
+    // 3. Run renderFunction main scene (appears below persistentScenes rendering)
     this.scene.renderFunction();
     
+    // 4. Run renderFunction for all persistentScenes (appears above main scene rendering)
     for (i = 0; i < this.persistentScenes.length; i++) {
         this.persistentScenes[i].renderFunction();
     }

--- a/convergame.js
+++ b/convergame.js
@@ -7,6 +7,8 @@ function Convergame(canvas) {
   var hasGP = false, repGP, axes;
 
   this.scene = null;
+  
+  this.persistentScenes = [];
 
   this.controlsMap = {};
 
@@ -26,9 +28,19 @@ function Convergame(canvas) {
     var now = Date.now();
     var delta = now - this.then;
     var time = delta / 1000;
+    
+    var i;
+
+    for (i = 0; i < this.persistentScenes.length; i++) {
+        this.persistentScenes[i].updateFunction(time);
+    }
 
     this.scene.updateFunction(time);
     this.scene.renderFunction();
+    
+    for (i = 0; i < this.persistentScenes.length; i++) {
+        this.persistentScenes[i].renderFunction();
+    }
 
     this.then = now;
     this.controlsPressed = [];
@@ -296,4 +308,22 @@ function Convergame(canvas) {
   this.postShake = function() {
     ctx.restore();
   };
+  
+  this.addPersistentScene = function(sceneObject) {
+    
+    // Run scene initialisation
+    sceneObject.init(this);
+    
+    // Add scene to persistentScenes array
+    this.persistentScenes.push(sceneObject);
+  };
+  
+  this.removePersistentScene = function(sceneObject) {
+
+    // Remove scene from persistentScenes array
+    var index = this.persistentScenes.indexOf(sceneObject);
+    this.persistentScenes.splice(index, 1);
+
+  };
+  
 }

--- a/persistentScenes/timeHUD.js
+++ b/persistentScenes/timeHUD.js
@@ -1,0 +1,22 @@
+
+function TimeHUD()
+{	
+    this.convergame = null;
+    
+    this.datetime = null;
+    
+    this.updateFunction = function(time)
+    {
+        this.datetime = new Date();
+    };
+    
+    this.renderFunction = function()
+    {
+		this.convergame.drawText(40, 60, "#ffffff", 20, "sans-serif", "left", this.datetime, true, 2, 2, "#000000");
+    };
+    
+    this.init = function(convergame)
+    {
+        this.convergame = convergame;
+    };
+}


### PR DESCRIPTION
This is a pull request to address issue #8.

It adds the logic to Convergame to handle persistent scenes, which are capable of running independently of the main scene. It allows adds a simple `TimeHUD` persistent scene which renders the current date time over the main scene's rendering.

------

A persistent scene's **update** function runs before that of the main scene. This means the main scene can potentially access data store by the persistent scene. This could be useful for added support for additional controllers and other modularised functionality.

A persistent scene's **render** function runs after that of the main scene. This means the persistent scene can draw on top of the content rendered by the main scene, allowing the creation of HUDs and overlays.

-----

I created a test 'game' (just two menus) that demonstrates how the persistent scene runs constantly and overlaps the rendering of the main scene.

Just `git clone https://github.com/DivineOmega/convergame-test-game.git` to test. :)